### PR TITLE
feat: Set MQTT publish retain flag to true

### DIFF
--- a/src/homeassistant/mod.rs
+++ b/src/homeassistant/mod.rs
@@ -228,7 +228,7 @@ impl HASensor {
             .publish(
                 &self.state_topic,
                 rumqttc::QoS::AtLeastOnce,
-                false,
+                true,
                 serde_json::to_string(&payload).expect("Failed to serialize"),
             )
             .await


### PR DESCRIPTION
Otherwise restarting HomeAssistant leads to the sensors having unknown values until the next scrape.